### PR TITLE
Set Security Guild as codeowner of security workflows

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 * @coopnorge/platform-guild
 CODEOWNERS                        @coopnorge/security-guild
+
+.github/workflows/security-* @coopnorge/security-guild


### PR DESCRIPTION

Closes: coopnorge/engineering-issues#133