### PR TITLE
sync argocd app before diff

### DIFF
--- a/.github/workflows/kubernetes-validation.yaml
+++ b/.github/workflows/kubernetes-validation.yaml
@@ -87,6 +87,10 @@ jobs:
         id: argocd-diff
         run: |
           set -x
+          ${ARGOCD_BIN} \
+            --auth-token ${ARGOCD_API_TOKEN:=EMPTY} \
+            --grpc-web --server $ARGOCD_URL \
+            app get ${{ matrix.argocd-appname}} --refresh
           set +e
           ${ARGOCD_BIN} \
             --auth-token ${ARGOCD_API_TOKEN:=EMPTY} \


### PR DESCRIPTION
This is to avoid a race condition in which the a branch is merged but the ArgoCD application isn't automatically refreshed before the github diff action is run, which means the diff is done against an outdated revision.