### PR TITLE
Set the component type to `library`

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,6 +11,6 @@ metadata:
   annotations:
     github.com/project-slug: coopnorge/github-workflow-kubernetes-validation
 spec:
-  type: component
+  type: lirabry
   lifecycle: production
   owner: cloud-platform


### PR DESCRIPTION
There are currently 3 know Component types in Inventory (Backstage). `service`, `website` and `library`. I think `library` is the right thing for this repository.