### PR TITLE
fix: Remove invalid input for release-drafter workflow

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -18,5 +18,3 @@ jobs:
       pull-requests: write
       contents: write
     uses: coopnorge/github-workflow-release-drafter/.github/workflows/release-drafter.yaml@v0
-    with:
-      ignore-major-changes-for-pattern: '(\S+)\/(v1beta1)\.(\S+)' # Do not replace single quotes with double quotes, single quotes are required to handle the escape characters properly.


### PR DESCRIPTION
ignore-major-changes-for-pattern is not a valid input for the workflow.

fixes: https://github.com/coopnorge/github-workflow-kubernetes-validation/issues/57