### PR TITLE
docs: Update dockerfile version in docs so that it has latest mage-kubernetes-lib

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     outputs:
-      run-techdocs-ci: ${{ steps.changes.outputs.techdocs == 'true' || github.event_name == 'workflow_dispatch' }}
+      run-techdocs-ci: ${{ steps.changes.outputs.techdocs == 'true' || steps.changes.outputs.devtools == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -22,6 +22,10 @@ jobs:
           filters: |
             techdocs:
               - 'docs/**'
+            devtools:
+              - 'devtools/Dockerfile'
+              - '.github/workflows/**'
+              - 'docker-compose.yaml'
       - name: Debug ...
         run: |
           echo "::${{ steps.changes.outputs }}"
@@ -50,4 +54,3 @@ jobs:
         name: "Catch errors"
         if: |
           needs.techdocs.result == 'failure'
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ Make sure you update your dependabot to update docker images in `docker-compose/
 
 ## V1 Docs
 
-### Inputs
+### v1 Inputs
 
 ```yaml
 inputs:

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ And have in your `docker-compose.yaml`
 ```yaml
   kubernetes-devtools:
     build:
-      context: docker-compose
+      context: devtools
       target: kubernetes-devtools
       dockerfile: Dockerfile
     privileged: false
@@ -43,13 +43,13 @@ And have in your `docker-compose.yaml`
       - $HOME/.argocd:/root/.config/argocd
 ```
 
-and in `docker-compose/Dockerfile` have atleast this image
+and in `devtools/Dockerfile` have atleast this image
 
 ```dockerfile
 FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-kubernetes-v1beta1:latest@sha256:6cab3cd24ce510d11105deb0777df7d2c2e959eaed44e049d5ecd2304e217a12 AS kubernetes-devtools
 ```
 
-Make sure you update your dependabot to update docker images in `docker-compose/Dockerfile`
+Make sure you update your dependabot to update docker images in `devtools/Dockerfile`
 
 ## Inputs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ And have in your `docker-compose.yaml`
 and in `docker-compose/Dockerfile` have atleast this image
 
 ```dockerfile
-FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-kubernetes-v1beta1:latest@sha256:db0e83c6ae634f27c14c1b3ff55e1b12d94066222380b1cada65ae72023b5fc6 AS kubernetes-devtools
+FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-kubernetes-v1beta1:latest@sha256:6cab3cd24ce510d11105deb0777df7d2c2e959eaed44e049d5ecd2304e217a12 AS kubernetes-devtools
 ```
 
 Make sure you update your dependabot to update docker images in `docker-compose/Dockerfile`


### PR DESCRIPTION
- Update image to the latest version in the docs so that it works with oci repos with helm. ref: https://github.com/coopnorge/mage-kubernetes-lib/releases/tag/v0.5.0
- Add expected directory for vale. ref: https://github.com/coopnorge/engineering-issues/issues/423
- Trigger `run-techdocs-ci` workflow when devtools are updated